### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python }}"
-      - uses: "actions/cache@v2"
+      - uses: "actions/cache@v3"
         id: "cache"
         with:
           path: "${{ env.pythonLocation }}"

--- a/xarray_selafin/xarray_backend.py
+++ b/xarray_selafin/xarray_backend.py
@@ -162,9 +162,9 @@ def write_serafin(fout, ds):
         temp = np.empty(shape, dtype=slf_header.np_float_type)
         for iv, var in enumerate(slf_header.var_IDs):
             if slf_header.nb_frames == 1:
-                temp[iv] = ds[var]
+                temp[iv] = ds[var].values
             else:
-                temp[iv] = ds.isel(time=it)[var]
+                temp[iv] = ds.isel(time=it)[var].values
             if slf_header.nb_planes > 1:
                 temp[iv] = np.reshape(np.ravel(temp[iv]), (slf_header.nb_planes, slf_header.nb_nodes_2d))
         resout.write_entire_frame(


### PR DESCRIPTION
Warnings which are fixed:

```
xarray_selafin\xarray_backend.py:165: DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.
  temp[iv] = ds[var]

xarray_selafin\xarray_backend.py:167: DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.
  temp[iv] = ds.isel(time=it)[var]
```